### PR TITLE
fix: typos in documentation and improve neg() tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-Thanks for your interest in contributing to the Transmuter system! Transmuter is a community built protocol and anyone
+Thanks for your interest in contributing to Parallel Protocol! Parallel Protocol is a community built project and anyone
 is welcome to improve it.
 
 If you need to get in contact with the repository maintainers, please reach out in the

--- a/contracts/libraries/CommonErrorsLib.sol
+++ b/contracts/libraries/CommonErrorsLib.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 /// @title CommonErrorsLib
 /// @author Cooper Labs
 /// @custom:contact security@cooperlabs.xyz
-/// @notice Library exposing all commun errors.
+/// @notice Library exposing all common errors.
 library CommonErrorsLib {
     /// @notice Thrown when the address is zero.
     error AddressZero();

--- a/tests/libraries/mathLib/neg.t.sol
+++ b/tests/libraries/mathLib/neg.t.sol
@@ -8,13 +8,18 @@ import { MathLib } from "contracts/libraries/MathLib.sol";
 contract MathLib_Neg_Test is Base_Test {
     using MathLib for uint256;
 
-    function test_neg(uint256 value) external pure{
-        vm.assume(value > 0 && value < uint256(type(int256).max));
+    function test_neg_zero() external pure {
+        uint256 value = 0;
+        assertEq(value.neg(), int256(0));
+    }
+
+    function test_neg_posValue(uint256 value) external pure {
+        vm.assume(value > 0 && value <= uint256(type(int256).max));
         assertEq(value.neg(), -int256(value));
     }
 
-    function test_neg_zero() external pure{
-        uint256 value = 0;
-        assertEq(value.neg(), 0);
+    function test_neg_maxValue() external pure {
+        uint256 value = uint256(type(int256).max);
+        assertEq(value.neg(), -int256(value));
     }
 }


### PR DESCRIPTION
## Description:

* Fix typo 'commun' → 'common' in [\parallel-protocol\parrallel-tokens\tree\main\contracts\libraries\CommonErrorsLib.sol](vscode-file://vscode-app/c:/Users/HomePC/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* Fix incorrect 'Transmuter system' reference in [\parallel-protocol\parrallel-tokens\tree\main\CONTRIBUTING.md](vscode-file://vscode-app/c:/Users/HomePC/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to 'Parallel Tokens'
* Improve neg() function tests with better coverage and edge cases